### PR TITLE
Print out exception message when one is thrown

### DIFF
--- a/lib/guard/konacha-rails/runner.rb
+++ b/lib/guard/konacha-rails/runner.rb
@@ -46,6 +46,7 @@ module Guard
         notify
       rescue => e
         UI.error(e)
+        UI.info(e.message)
       end
 
       private


### PR DESCRIPTION
It's very helpful when debugging silly mistakes:

Before
![screenshot at 2017-02-22 14-15-49](https://cloud.githubusercontent.com/assets/2295892/23195942/73145b68-f90a-11e6-84b8-8ec51e12e8cd.png)

After
![screenshot at 2017-02-22 14-16-45](https://cloud.githubusercontent.com/assets/2295892/23195943/76ad66d4-f90a-11e6-85bc-03c68277c8f2.png)

