### PR TITLE
Remove gemnasium

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -2,7 +2,6 @@
 
 [![Gem Version](https://badge.fury.io/rb/guard-konacha-rails.png)](http://badge.fury.io/rb/guard-konacha-rails)
 [![Build Status](https://travis-ci.org/keithpitty/guard-konacha-rails.png)](https://travis-ci.org/keithpitty/guard-konacha-rails)
-[![Dependency Status](https://gemnasium.com/lbeder/guard-konacha-rails.png)](https://gemnasium.com/lbeder/guard-konacha-rails)
 [![Coverage Status](https://coveralls.io/repos/lbeder/guard-konacha-rails/badge.svg)](https://coveralls.io/r/lbeder/guard-konacha-rails)
 
 Automatically run your [Konacha](https://github.com/jfirebaugh/konacha) tests through [Guard](https://github.com/guard/guard/).


### PR DESCRIPTION
The Dependency Status badge that was provided by gemnasium is being removed for now. A gemnasium account costs $15 per month, which I can't justify for this project at the moment.