### PR TITLE
Fix template

### DIFF
--- a/lib/guard/konacha-rails/templates/Guardfile
+++ b/lib/guard/konacha-rails/templates/Guardfile
@@ -5,6 +5,7 @@
 #  - :rails_environment_file, location of rails environment file,
 #    should be able to find it automatically
 guard 'konacha-rails' do
-  watch(%r{^app/assets/javascripts/(.*)\.(js|coffee)?$}) { |m| "#{m[1]}_spec.js" }
+  # alter the next line if necessary e.g. if your js specs are coffee files
+  watch(%r{^app/assets/javascripts/(.*)\.(js|coffee)?$}) { |m| "spec/javascripts/#{m[1]}_spec.js" }
   watch(%r{^(test|spec)/javascripts/.+_(test|spec)\.(js|coffee)$})
 end


### PR DESCRIPTION
The template used to generate the konacha-rails section of the Guardfile would be more helpful if it assumes that specs are within the `spec/javascripts` folder.

This is intended to address issue https://github.com/keithpitty/guard-konacha-rails/issues/9.